### PR TITLE
pyopenssl >=17.5.0,<=22.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,7 +22,7 @@ requirements:
     - python >=3.6
     - certifi
     - cryptography >=3.2.1,<=39.0.0
-    - pyopenssl >=17.5.0,<=22.0.0
+    - pyopenssl >=17.5.0,<=22.1.0
     - python-dateutil >=2.5.3,<3.0.0
     - pytz >=2016.10
     - circuitbreaker >=1.3.1,<2.0.0


### PR DESCRIPTION
fix upper found for pyopenssl
https://github.com/oracle/oci-python-sdk/blob/v2.89.0/setup.py#L32-L40